### PR TITLE
Use GVAR_FUNC and some cleanup

### DIFF
--- a/gap/PackageMaker.gi
+++ b/gap/PackageMaker.gi
@@ -224,7 +224,9 @@ BindGlobal( "PkgAuthorRecs", function()
     pers:=[];
     for pkgname in RecNames(GAPInfo.PackagesInfo) do
         for pkg in GAPInfo.PackagesInfo.(pkgname) do
-            Append(pers, pkg.Persons);
+            if IsBound(pkg.Persons) then
+                Append(pers, pkg.Persons);
+            fi;
         od;
     od;
 

--- a/templates/PackageInfo.g.in
+++ b/templates/PackageInfo.g.in
@@ -39,8 +39,8 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">= 4.8",
-  NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ] ],
+  GAP := ">= 4.9",
+  NeededOtherPackages := [ [ "GAPDoc", ">= 1.6.1" ] ],
   SuggestedOtherPackages := [ ],
   ExternalConditions := [ ],
 ),

--- a/templates/src/PKG.c
+++ b/templates/src/PKG.c
@@ -5,33 +5,23 @@
 #include "src/compiled.h"          /* GAP headers */
 
 
-Obj TestCommand(Obj self)
+Obj FuncTestCommand(Obj self)
 {
     return INTOBJ_INT(42);
 }
 
-Obj TestCommandWithParams(Obj self, Obj param, Obj param2)
+Obj FuncTestCommandWithParams(Obj self, Obj param, Obj param2)
 {
     /* simply return the first parameter */
     return param;
 }
 
-
-typedef Obj (* GVarFunc)(/*arguments*/);
-
-#define GVAR_FUNC_TABLE_ENTRY(srcfile, name, nparam, params) \
-  {#name, nparam, \
-   params, \
-   (GVarFunc)name, \
-   srcfile ":Func" #name }
-
 // Table of functions to export
 static StructGVarFunc GVarFuncs [] = {
-    GVAR_FUNC_TABLE_ENTRY("{{PackageName}}.c", TestCommand, 0, ""),
-    GVAR_FUNC_TABLE_ENTRY("{{PackageName}}.c", TestCommandWithParams, 2, "param, param2"),
+    GVAR_FUNC(TestCommand, 0, ""),
+    GVAR_FUNC(TestCommandWithParams, 2, "param, param2"),
 
-	{ 0 } /* Finish with an empty entry */
-
+    { 0 } /* Finish with an empty entry */
 };
 
 /******************************************************************************
@@ -39,10 +29,10 @@ static StructGVarFunc GVarFuncs [] = {
 */
 static Int InitKernel( StructInitInfo *module )
 {
-    /* init filters and functions                                          */
+    /* init filters and functions */
     InitHdlrFuncsFromTable( GVarFuncs );
 
-    /* return success                                                      */
+    /* return success */
     return 0;
 }
 
@@ -54,7 +44,7 @@ static Int InitLibrary( StructInitInfo *module )
     /* init filters and functions */
     InitGVarFuncsFromTable( GVarFuncs );
 
-    /* return success                                                      */
+    /* return success */
     return 0;
 }
 

--- a/templates/src/PKG.cc
+++ b/templates/src/PKG.cc
@@ -9,37 +9,27 @@
 #include <gmp.h>
 
 extern "C" {
-#include "src/compiled.h"          /* GAP headers                */
+#include "src/compiled.h"          /* GAP headers */
 }
 
 
-Obj TestCommand(Obj self)
+Obj FuncTestCommand(Obj self)
 {
     return INTOBJ_INT(42);
 }
 
-Obj TestCommandWithParams(Obj self, Obj param, Obj param2)
+Obj FuncTestCommandWithParams(Obj self, Obj param, Obj param2)
 {
     /* simply return the first parameter */
     return param;
 }
 
-
-typedef Obj (* GVarFunc)(/*arguments*/);
-
-#define GVAR_FUNC_TABLE_ENTRY(srcfile, name, nparam, params) \
-  {#name, nparam, \
-   params, \
-   (GVarFunc)name, \
-   srcfile ":Func" #name }
-
 // Table of functions to export
 static StructGVarFunc GVarFuncs [] = {
-    GVAR_FUNC_TABLE_ENTRY("{{PackageName}}.c", TestCommand, 0, ""),
-    GVAR_FUNC_TABLE_ENTRY("{{PackageName}}.c", TestCommandWithParams, 2, "param, param2"),
+    GVAR_FUNC(TestCommand, 0, ""),
+    GVAR_FUNC(TestCommandWithParams, 2, "param, param2"),
 
-	{ 0 } /* Finish with an empty entry */
-
+    { 0 } /* Finish with an empty entry */
 };
 
 /******************************************************************************
@@ -47,10 +37,10 @@ static StructGVarFunc GVarFuncs [] = {
 */
 static Int InitKernel( StructInitInfo *module )
 {
-    /* init filters and functions                                          */
+    /* init filters and functions */
     InitHdlrFuncsFromTable( GVarFuncs );
 
-    /* return success                                                      */
+    /* return success */
     return 0;
 }
 
@@ -62,7 +52,7 @@ static Int InitLibrary( StructInitInfo *module )
     /* init filters and functions */
     InitGVarFuncsFromTable( GVarFuncs );
 
-    /* return success                                                      */
+    /* return success */
     return 0;
 }
 


### PR DESCRIPTION
This PR does two things:

 * It adapts the c and cc templates to use GVAR_FUNC from the GAP kernel
 * It checks that Persons is bound when looking for people that could be authors. This just makes PackageMaker more robust against people having incomplete PackageInfo files lying around.

Note that I couldn't test this yet as #38 blocks that.