### PR TITLE
Ask for person GitHub usernames

### DIFF
--- a/gap/input.g
+++ b/gap/input.g
@@ -205,7 +205,9 @@ BindGlobal( "PKGMKR_AskQuestions", function( spec, ui, answers )
     return answers;
 end );
 
-BindGlobal( "EXTRA_PERSON_KEYS", [ "Email", "WWWHome", "Institution", "Place", "PostalAddress"] );
+BindGlobal( "EXTRA_PERSON_KEYS",
+    [ "Email", "WWWHome", "GitHubUsername",
+      "Institution", "Place", "PostalAddress" ] );
 
 BindGlobal( "PKGMKR_PrintMessage", function( prompt )
     local line;
@@ -505,23 +507,38 @@ BindGlobal( "PKGMKR_AskPersons", function()
         name := Concatenation(p.LastName, ", ", p.FirstNames);
         for key in EXTRA_PERSON_KEYS do
             q := Concatenation(key, "?");
-            if IsBound(pers.(name)) then
-                tmp := pers.(name).(key);
-            else
-                tmp := [];
-            fi;
-            if Length(tmp) = 0 then
-                p.(key) := AskQuestion(q);
-            elif Length(tmp) = 1 then
-                p.(key) := AskQuestion(q : default := tmp[1]);
-            else
-                tmp := List(tmp, x -> [x,x]);
-                Add(tmp, ["other", fail]);
-                p.(key) := AskAlternativesQuestion(q, tmp);
-                if p.(key) = fail then
-                    p.(key) := AskQuestion(q);
+            while true do
+                if IsBound(pers.(name)) then
+                    tmp := pers.(name).(key);
+                else
+                    tmp := [];
                 fi;
-            fi;
+                if Length(tmp) = 0 then
+                    p.(key) := AskQuestion(q);
+                elif Length(tmp) = 1 then
+                    p.(key) := AskQuestion(q : default := tmp[1]);
+                else
+                    tmp := List(tmp, x -> [x,x]);
+                    Add(tmp, ["other", fail]);
+                    p.(key) := AskAlternativesQuestion(q, tmp);
+                    if p.(key) = fail then
+                        p.(key) := AskQuestion(q);
+                    fi;
+                fi;
+
+                if p.(key) = "" then
+                    break;
+                fi;
+                if key = "GitHubUsername" then
+                    tmp := PKGMKR_CheckGitHubUsername( p, p.(key) );
+                    if tmp = true then
+                        break;
+                    fi;
+                    Print( tmp, "\n" );
+                else
+                    break;
+                fi;
+            od;
             if p.(key) = "" then
                 p.(key) := DISABLED_ENTRY;
             else

--- a/gap/input.g
+++ b/gap/input.g
@@ -291,22 +291,22 @@ BindGlobal( "PKGMKR_ValidateSubtitle", function( answers, value )
 end );
 
 BindGlobal( "PKGMKR_CheckGitHubUsername", function( answers, value )
-    if IsString( value )
-       and ( StartsWith( value, "http://" )
-             or StartsWith( value, "https://" )
-             or StartsWith( value, "ftp://" )
-             or ( 0 < Length( value ) and value[1] = '@' ) ) then
-        return "The GitHub username must be written without '@' or a URL.";
+    local len;
+
+    if not IsString( value ) then
+        return "The GitHub username must be a valid GitHub username.";
     fi;
 
-    if 0 < Length( value ) and value[1] <> '-'
-       and ForAll( value, c -> IsAlphaChar( c ) or IsDigitChar( c ) or c = '-' ) then
+    len := Length( value );
+    if 0 < len and len <= 39
+       and value[1] <> '-' and value[len] <> '-'
+       and ForAll( value, c -> IsAlphaChar( c ) or IsDigitChar( c ) or c = '-' )
+       and not ForAny( [ 1 .. len - 1 ],
+                       i -> value[i] = '-' and value[i+1] = '-' ) then
         return true;
     fi;
 
-    return Concatenation(
-        "The name must be nonempty, consist of alphanumerical ",
-        "characters or '-', and must not start with '-'." );
+    return "The GitHub username must be a valid GitHub username.";
 end );
 
 BindGlobal( "PKGMKR_CheckRepositoryName", function( answers, value )

--- a/gap/input.g
+++ b/gap/input.g
@@ -289,6 +289,14 @@ BindGlobal( "PKGMKR_ValidateSubtitle", function( answers, value )
 end );
 
 BindGlobal( "PKGMKR_CheckGitHubUsername", function( answers, value )
+    if IsString( value )
+       and ( StartsWith( value, "http://" )
+             or StartsWith( value, "https://" )
+             or StartsWith( value, "ftp://" )
+             or ( 0 < Length( value ) and value[1] = '@' ) ) then
+        return "The GitHub username must be written without '@' or a URL.";
+    fi;
+
     if 0 < Length( value ) and value[1] <> '-'
        and ForAll( value, c -> IsAlphaChar( c ) or IsDigitChar( c ) or c = '-' ) then
         return true;

--- a/tst/DemoPackage.expected/PackageInfo.g
+++ b/tst/DemoPackage.expected/PackageInfo.g
@@ -23,6 +23,7 @@ Persons := [
     IsAuthor := true,
     IsMaintainer := true,
     PostalAddress := "123 Test Street\n12345 Test City",
+    GitHubUsername := "demo-user",
     Place := "Test City",
     Institution := "PackageMaker Test Suite",
   ),

--- a/tst/input.tst
+++ b/tst/input.tst
@@ -144,13 +144,25 @@ gap> ui.state.calls[4].choices;
 gap> PKGMKR_CheckGitHubUsername( rec(), "octo-cat" );
 true
 gap> PKGMKR_CheckGitHubUsername( rec(), "-octo-cat" ) =
-> "The name must be nonempty, consist of alphanumerical characters or '-', and must not start with '-'.";
+> "The GitHub username must be a valid GitHub username.";
 true
 gap> PKGMKR_CheckGitHubUsername( rec(), "@octo-cat" ) =
-> "The GitHub username must be written without '@' or a URL.";
+> "The GitHub username must be a valid GitHub username.";
 true
 gap> PKGMKR_CheckGitHubUsername( rec(), "https://github.com/octo-cat" ) =
-> "The GitHub username must be written without '@' or a URL.";
+> "The GitHub username must be a valid GitHub username.";
+true
+gap> PKGMKR_CheckGitHubUsername( rec(), "octo--cat" ) =
+> "The GitHub username must be a valid GitHub username.";
+true
+gap> PKGMKR_CheckGitHubUsername( rec(), "octo-cat-" ) =
+> "The GitHub username must be a valid GitHub username.";
+true
+gap> PKGMKR_CheckGitHubUsername( rec(), "octo_cat" ) =
+> "The GitHub username must be a valid GitHub username.";
+true
+gap> PKGMKR_CheckGitHubUsername( rec(), "1234567890123456789012345678901234567890" ) =
+> "The GitHub username must be a valid GitHub username.";
 true
 gap> PKGMKR_CheckRepositoryName( rec(), "demo.repo" );
 true

--- a/tst/input.tst
+++ b/tst/input.tst
@@ -146,6 +146,12 @@ true
 gap> PKGMKR_CheckGitHubUsername( rec(), "-octo-cat" ) =
 > "The name must be nonempty, consist of alphanumerical characters or '-', and must not start with '-'.";
 true
+gap> PKGMKR_CheckGitHubUsername( rec(), "@octo-cat" ) =
+> "The GitHub username must be written without '@' or a URL.";
+true
+gap> PKGMKR_CheckGitHubUsername( rec(), "https://github.com/octo-cat" ) =
+> "The GitHub username must be written without '@' or a URL.";
+true
 gap> PKGMKR_CheckRepositoryName( rec(), "demo.repo" );
 true
 gap> PKGMKR_CheckRepositoryName( rec(), "-demo" ) =

--- a/tst/utils.g
+++ b/tst/utils.g
@@ -11,6 +11,7 @@ BindGlobal( "PKGMKR_DemoPackageAnswers", function()
             rec(
                 Email := "demo@example.invalid",
                 FirstNames := "Demo",
+                GitHubUsername := "demo-user",
                 Institution := "PackageMaker Test Suite",
                 IsAuthor := true,
                 IsMaintainer := true,


### PR DESCRIPTION
Part of resolving https://github.com/gap-system/gap/issues/4784. This should be merged if and only if https://github.com/gap-system/gap/pull/6497 is merged.

## Summary

- reject GitHub usernames entered as profile URLs or `@` mentions
- ask for `GitHubUsername` in wizard person records
- include the new person field in the generated package fixture

Created using Codex (GPT-5.5) <codex@openai.com>